### PR TITLE
Fix tag builds in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
       - setup_remote_docker
       - run: |
             export IMAGE_NAME=$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
-            export IMAGE_TAG=`if [ -n “$CIRCLE_TAG” ]; then echo latest; else echo $CIRCLE_TAG; fi`
+            export IMAGE_TAG=`if [ -z $CIRCLE_TAG ]; then echo latest; else echo $CIRCLE_TAG; fi`
             echo "Building Docker image $IMAGE_NAME:$IMAGE_TAG"
             make
             echo $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin
@@ -76,5 +76,22 @@ workflows:
             branches:
               only:
                 - master
+
+  release:
+    jobs:
+      - test:
+          filters:  # filters are required to match build-and-publish job since it requires this one
             tags:
               only: /^v.*/
+            branches:
+              ignore: /.*/
+
+      - build-and-publish:
+          context: containershipbot
+          requires:
+            - test
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![CircleCI](https://circleci.com/gh/containership/infrastructure-controller.svg?style=svg)](https://circleci.com/gh/containership/infrastructure-controller)
+[![Go Report Card](https://goreportcard.com/badge/github.com/containership/infrastructure-controller)](https://goreportcard.com/report/github.com/containership/infrastructure-controller)
+[![codecov](https://codecov.io/gh/containership/infrastructure-controller/branch/master/graph/badge.svg)](https://codecov.io/gh/containership/infrastructure-controller)
+
 # Containership Cloud Infrastructure Controller
 
 The infrastructure controller is a simple controller for augmenting the functionality of Containership Kubernetes Engine (CKE) clusters in ways that are specific to infrastructure management.


### PR DESCRIPTION
### Description

#### What does this pull request accomplish?

Fix tag builds in CircleCI

They weren't working because any job that defines a tag filter must also ensure that all jobs it depends on have that same tag filter.

#### What issue(s) does this fix?
* None

#### Additional Considerations

### Testing

Tested on my fork